### PR TITLE
fix/es_retention_setup

### DIFF
--- a/setup/so-functions
+++ b/setup/so-functions
@@ -1011,6 +1011,10 @@ elasticsearch_pillar() {
         "        bool:"\
         "          max_clause_count: 3500"\
                 "  index_settings: {}" > $elasticsearch_pillar_file
+        if "${elasticsearch_retain_more}"; then
+                printf "  retention:"\
+                       "    retention_pct: 80" >> $elasticsearch_pillar_file
+        fi
 }
 
 es_heapsize() {
@@ -2118,35 +2122,18 @@ set_progress_str() {
 }
 
 set_default_log_size() {
-	local percentage
 
 	case $install_type in
 		STANDALONE | EVAL | HEAVYNODE)
-			percentage=50
+			if mountpoint -q /nsm/elasticsearch; then
+				elasticsearch_retain_more=YES
+			fi
 		;;
 		*)
-			percentage=80
+			elasticsearch_retain_more=YES
 		;;
 	esac
 
-	local disk_dir="/"
-	if mountpoint -q /nsm; then
-		disk_dir="/nsm"
-	fi
-	if mountpoint -q /nsm/elasticsearch; then
-		disk_dir="/nsm/elasticsearch"
-		percentage=80
-	fi
-	
-	local disk_size_1k
-	disk_size_1k=$(df $disk_dir | grep -v "^Filesystem" | awk '{print $2}')
-
-	local ratio="1048576"
-
-	local disk_size_gb
-	disk_size_gb=$( echo "$disk_size_1k" "$ratio" | awk '{print($1/$2)}' )
-
-	log_size_limit=$( echo "$disk_size_gb" "$percentage" | awk '{printf("%.0f", $1 * ($2/100))}')
 }
 
 set_desktop_background() {

--- a/setup/so-setup
+++ b/setup/so-setup
@@ -433,7 +433,7 @@ if ! [[ -f $install_opt_file ]]; then
 		[[ ! $is_airgap ]] && detect_cloud
 		# Sets some minion info
 		set_minion_info
-		set_default_log_size >> $setup_log 2>&1
+		set_default_log_size
 		info "Verifying all network devices are managed by Network Manager that should be"
 		check_network_manager_conf
 		set_network_dev_status_list
@@ -460,7 +460,7 @@ if ! [[ -f $install_opt_file ]]; then
 		collect_dockernet
 		[[ ! $is_airgap ]] && detect_cloud
 		set_minion_info
-		set_default_log_size >> $setup_log 2>&1
+		set_default_log_size
 		info "Verifying all network devices are managed by Network Manager that should be"
 		check_network_manager_conf
 		set_network_dev_status_list
@@ -482,7 +482,7 @@ if ! [[ -f $install_opt_file ]]; then
 		collect_dockernet
 		[[ ! $is_airgap ]] && detect_cloud
 		set_minion_info
-		set_default_log_size >> $setup_log 2>&1
+		set_default_log_size
 		info "Verifying all network devices are managed by Network Manager that should be"
 		check_network_manager_conf
 		set_network_dev_status_list
@@ -503,7 +503,7 @@ if ! [[ -f $install_opt_file ]]; then
 		collect_dockernet
 		[[ ! $is_airgap ]] && detect_cloud
 		set_minion_info
-		set_default_log_size >> $setup_log 2>&1
+		set_default_log_size
 		info "Verifying all network devices are managed by Network Manager that should be"
 		check_network_manager_conf
 		set_network_dev_status_list
@@ -593,7 +593,7 @@ if ! [[ -f $install_opt_file ]]; then
 		collect_dockernet
 		[[ ! $is_airgap ]] && collect_net_method
 		set_minion_info
-		set_default_log_size >> $setup_log 2>&1
+		set_default_log_size
 		info "Verifying all network devices are managed by Network Manager that should be"
 		check_network_manager_conf
 		set_network_dev_status_list

--- a/setup/so-whiptail
+++ b/setup/so-whiptail
@@ -789,32 +789,6 @@ whiptail_invalid_hostname() {
 	--msgbox "$error_message" 10 75
 }
 
-whiptail_log_size_limit() {
-
-	[ -n "$TESTING" ] && return
-
-	case $install_type in
-		STANDALONE | EVAL | HEAVYNODE)
-			percentage=50
-		;;
-		*)
-			percentage=80
-		;;
-	esac
-
-	read -r -d '' message <<- EOM
-	Please specify the amount of disk space (in GB) you would like to allocate for Elasticsearch data storage.
-
-	By default, this is set to ${percentage}% of the disk space allotted for /nsm.
-	EOM
-	
-	log_size_limit=$(whiptail --title "$whiptail_title" --inputbox "$message" 11 75 "$1" 3>&1 1>&2 2>&3)
-
-	local exitstatus=$?
-	whiptail_check_exitstatus $exitstatus
-
-}
-
 whiptail_first_menu_iso() {
 	[ -n "$TESTING" ] && return
 


### PR DESCRIPTION
This patch restores a feature of v2.3 where elasticsearch can use up to 80% of the disk in certain situations.

If the system does not store sensor data (eg. is standalone, eval, or heave node), or if the /nsm/elasticsearch directory is its own filesystem, then more than the default 50% can be used.  This patch checks for those conditions on setup and if matched, sets the retention_pct grain at 80% in the elasticsearch pillar.

Since disk size calculations have been moved to so-elasticsearch-cluster-* scripts, and are no longer needed here for calculating the percentage in bytes, they are removed from set_default_log_size() for clarity.